### PR TITLE
Add a fallback generator to overcome when the generated gin module is created too late

### DIFF
--- a/dispatch-rest-delegates/src/main/java/com/gwtplatform/dispatch/rest/delegates/rebind/DelegateGenerator.java
+++ b/dispatch-rest-delegates/src/main/java/com/gwtplatform/dispatch/rest/delegates/rebind/DelegateGenerator.java
@@ -127,6 +127,8 @@ public class DelegateGenerator extends AbstractVelocityGenerator
         JClassType resourceInterface = resourceDefinition.getResourceInterface();
 
         variables.put("resourceType", new ClassDefinition(resourceInterface).getParameterizedClassName());
+        variables.put("resourceImplType", resourceDefinition.getParameterizedClassName());
+        variables.put("isSubResource", isSubResource());
         variables.put("methods", methodDefinitions);
         variables.put("imports", imports);
     }

--- a/dispatch-rest-delegates/src/main/java/com/gwtplatform/dispatch/rest/delegates/rebind/fallback/ResourceDelegateFallbackGenerator.java
+++ b/dispatch-rest-delegates/src/main/java/com/gwtplatform/dispatch/rest/delegates/rebind/fallback/ResourceDelegateFallbackGenerator.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015 ArcBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.gwtplatform.dispatch.rest.delegates.rebind.fallback;
+
+import java.io.PrintWriter;
+
+import com.google.gwt.core.ext.Generator;
+import com.google.gwt.core.ext.GeneratorContext;
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.core.ext.TreeLogger.Type;
+import com.google.gwt.core.ext.UnableToCompleteException;
+import com.google.gwt.core.ext.typeinfo.JClassType;
+import com.google.gwt.core.ext.typeinfo.JParameterizedType;
+import com.google.gwt.core.ext.typeinfo.NotFoundException;
+import com.google.gwt.core.ext.typeinfo.TypeOracle;
+import com.google.gwt.user.rebind.ClassSourceFileComposerFactory;
+import com.google.gwt.user.rebind.SourceWriter;
+import com.gwtplatform.dispatch.rest.delegates.client.ResourceDelegate;
+
+public class ResourceDelegateFallbackGenerator extends Generator {
+    private TreeLogger logger;
+    private GeneratorContext context;
+    private TypeOracle typeOracle;
+    private String typeName;
+
+    @Override
+    public String generate(TreeLogger logger, GeneratorContext context, String typeName)
+            throws UnableToCompleteException {
+        this.logger = logger;
+        this.context = context;
+        this.typeName = typeName;
+        this.typeOracle = context.getTypeOracle();
+
+        try {
+            tryGenerateDelegate();
+            return typeName + "Impl";
+        } catch (NotFoundException e) {
+            logger.log(Type.ERROR, "Can't find resource delegate." , e);
+        }
+
+        throw new UnableToCompleteException();
+    }
+
+    private void tryGenerateDelegate() throws NotFoundException, UnableToCompleteException {
+        JClassType resourceDelegateType = typeOracle.getType(ResourceDelegate.class.getName());
+
+        JClassType type = typeOracle.getType(typeName);
+        JClassType[] implementedInterfaces = type.getImplementedInterfaces();
+
+        for (JClassType implementedInterface : implementedInterfaces) {
+            if (implementedInterface.isAssignableTo(resourceDelegateType)) {
+                doGenerate(type, implementedInterface);
+                return;
+            }
+        }
+
+        throw new UnableToCompleteException();
+    }
+
+    private void doGenerate(JClassType type, JClassType implementedInterface) {
+        JClassType resourceType = extractResourceType(implementedInterface);
+
+        String packageName = type.getPackage().getName();
+        String className = type.getSimpleSourceName() + "Impl";
+
+        PrintWriter printWriter = context.tryCreate(logger, packageName, className);
+        if (printWriter != null) {
+            try {
+                compose(type, resourceType, packageName, className, printWriter);
+            } finally {
+                printWriter.close();
+            }
+        }
+    }
+
+    private JClassType extractResourceType(JClassType implementedInterface) {
+        JParameterizedType parameterized = implementedInterface.isParameterized();
+        JClassType[] typeArgs = parameterized.getTypeArgs();
+        return typeArgs[0];
+    }
+
+    private void compose(JClassType type, JClassType resourceType, String packageName, String className,
+            PrintWriter printWriter) {
+        ClassSourceFileComposerFactory composer
+                = new ClassSourceFileComposerFactory(packageName, className);
+        composer.addImplementedInterface(type.getName());
+        composer.setSuperclass(resourceType.getQualifiedSourceName() + "Delegate");
+
+        SourceWriter sourceWriter = composer.createSourceWriter(context, printWriter);
+        sourceWriter.commit(logger);
+    }
+}

--- a/dispatch-rest-delegates/src/main/resources/com/gwtplatform/dispatch/rest/delegates/ResourceDelegate.gwt.xml
+++ b/dispatch-rest-delegates/src/main/resources/com/gwtplatform/dispatch/rest/delegates/ResourceDelegate.gwt.xml
@@ -6,4 +6,8 @@
 
     <extend-configuration-property name="gwtp.dispatch.rest.generatorModules"
             value="com.gwtplatform.dispatch.rest.delegates.rebind.DelegateModule"/>
+
+    <generate-with class="com.gwtplatform.dispatch.rest.delegates.rebind.fallback.ResourceDelegateFallbackGenerator">
+        <when-type-assignable class="com.gwtplatform.dispatch.rest.delegates.client.ResourceDelegate"/>
+    </generate-with>
 </module>

--- a/dispatch-rest-delegates/src/main/resources/com/gwtplatform/dispatch/rest/delegates/rebind/Delegate.vm
+++ b/dispatch-rest-delegates/src/main/resources/com/gwtplatform/dispatch/rest/delegates/rebind/Delegate.vm
@@ -3,6 +3,7 @@ package $package;
 import javax.inject.Inject;
 
 import com.gwtplatform.dispatch.rest.client.RestDispatch;
+import com.gwtplatform.dispatch.rest.client.core.StaticParametersFactory;
 import com.gwtplatform.dispatch.rest.delegates.client.AbstractResourceDelegate;
 #foreach ($import in $imports)
 import $import;
@@ -11,7 +12,13 @@ import $import;
 public class $impl extends AbstractResourceDelegate<$resourceType> implements $resourceType {
     private final $resourceType resource;
 
+#if(!$isSubResource)
+    public ${impl}() {
+        this(StaticParametersFactory.getRestDispatch(), new ${resourceImplType}());
+    }
+
     @Inject
+#end
     public ${impl}(
             RestDispatch dispatcher,
             $resourceType resource) {


### PR DESCRIPTION
Relates to https://github.com/ArcBees/GWTP/pull/695

In order to work this out, client code is required to create an interface that extends `ResourceDelegate<>`. This is required because GWT generators don't preserve type arguments. **The workaround is not required if the generated GIN module works in your project**. ie:
```java
    interface CarsDelegate extends ResourceDelegate<CarsResource> {
    }
```