### PR TITLE
Add getResource for use cases where an Action object is required

### DIFF
--- a/dispatch-rest-delegates/src/main/java/com/gwtplatform/dispatch/rest/delegates/client/ResourceDelegate.java
+++ b/dispatch-rest-delegates/src/main/java/com/gwtplatform/dispatch/rest/delegates/client/ResourceDelegate.java
@@ -90,4 +90,9 @@ public interface ResourceDelegate<T> {
      * This method is the same as colling {@link #withCallback(AsyncCallback)} with a no-op callback.
      */
     T withoutCallback();
+
+    /**
+     * Retrieves the pure resource.
+     */
+    T getResource();
 }

--- a/dispatch-rest-delegates/src/main/resources/com/gwtplatform/dispatch/rest/delegates/rebind/Delegate.vm
+++ b/dispatch-rest-delegates/src/main/resources/com/gwtplatform/dispatch/rest/delegates/rebind/Delegate.vm
@@ -36,6 +36,11 @@ $method.output
     }
 
     @Override
+    public $resourceType getResource() {
+        return resource;
+    }
+
+    @Override
     protected $impl newInstance() {
         return new ${impl}(dispatcher, resource);
     }


### PR DESCRIPTION
I need the pure resources when I use a DispatchQueue. This won't be used in most cases since one of the benefits is that it removes the need for declaring RestAction in the resource.